### PR TITLE
fix some of the warnings

### DIFF
--- a/nightly_cluster.sh
+++ b/nightly_cluster.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ -z ${API_KEY} ];then
+if [ -z "${API_KEY}" ];then
     echo "No api key detected! Error!"
     echo "export API_KEY to continue"
     exit 1
@@ -10,22 +10,22 @@ export PATH=${PATH}:${HOME}/local/bin/
 echo which ibmcloud
 which ibmcloud
 
-ibmcloud login --apikey ${API_KEY} -a https://api.us-east.bluemix.net
+ibmcloud login --apikey "${API_KEY}" -a https://api.us-east.bluemix.net
 
 
 echo "Performing nightly cluster-rebuild"
 date=$(date +%F)
 yesterday=$(date --date yesterday +%F)
 
-echo ibmcloud ks cluster-create --name nibz-nightly-${date} --zone wdc06 --machine-type u2c.2x4 --private-vlan 2245765 --public-vlan 2245763
+echo ibmcloud ks cluster-create --name "nibz-nightly-${date}" --zone wdc06 --machine-type u2c.2x4 --private-vlan 2245765 --public-vlan 2245763
 
-ibmcloud ks cluster-create --name nibz-nightly-${date} --zone wdc06 --machine-type u2c.2x4 --private-vlan 2245765 --public-vlan 2245763
+ibmcloud ks cluster-create --name "nibz-nightly-${date}" --zone wdc06 --machine-type u2c.2x4 --private-vlan 2245765 --public-vlan 2245763
 
 sleep 2
 
-echo ibmcloud ks cluster-rm nibz-nightly-${yesterday} -f
+echo ibmcloud ks cluster-rm "nibz-nightly-${yesterday}" -f
 
-ibmcloud ks cluster-rm nibz-nightly-${yesterday} -f
+ibmcloud ks cluster-rm "nibz-nightly-${yesterday}" -f
 
 echo "ibmcloud ks clusters | grep nibz"
 


### PR DESCRIPTION
Fixed some shellcheck warnings (see https://github.com/koalaman/shellcheck )

You could also refactor these two variables to make it more DRY:
- "nibz-nightly-${date}" and
- "nibz-nightly-${yesterday}"